### PR TITLE
[ Info ] : Link break warnings for self host

### DIFF
--- a/content/2.setup/1.Silly-Little-Files.md
+++ b/content/2.setup/1.Silly-Little-Files.md
@@ -36,5 +36,5 @@ You will also need to add a repository secret in your settings with your service
 After all this, each time you push or modify something in the repo, it should update in the deployment.
 
 ::alert{type="info"}
-If this is too hard, you can also use another static site hosting provider :D
+Note that some links may break in this documentation if you are not hosting on a custom domain, as this guide expects you to. However, as is the nature with any open source project, you can simply edit it.
 ::

--- a/content/2.setup/1.Silly-Little-Files.md
+++ b/content/2.setup/1.Silly-Little-Files.md
@@ -35,6 +35,6 @@ You will also need to add a repository secret in your settings with your service
 
 After all this, each time you push or modify something in the repo, it should update in the deployment.
 
-::alert{type="info"}
+::alert{type="warning"}
 Note that some links may break in this documentation if you are not hosting on a custom domain, as this guide expects you to. However, as is the nature with any open source project, you can simply edit it.
 ::

--- a/content/2.setup/2.acprox.md
+++ b/content/2.setup/2.acprox.md
@@ -8,6 +8,7 @@ First Clone it with [this link](https://vercel.com/new/git/external?repository-u
 Vercel will help you make a new repo and deploy it..... and that should be it.
 
 After that you can also setup any custom domains in Settings > Domains
-::alert{type="info"}
-Note that some links may break in this documentation if you are not hosting on a custom domain (the links to the status page and main website on the homepage), as this guide expects you to. However, as is the nature with any open source project, you can simply edit it.
+
+::alert{type="warning"}
+Note that some links may break in this app if you are not hosting on a custom domain (the links to the status page and main website on the homepage), as this guide expects you to. However, as is the nature with any open source project, you can simply edit it.
 ::

--- a/content/2.setup/2.acprox.md
+++ b/content/2.setup/2.acprox.md
@@ -8,3 +8,6 @@ First Clone it with [this link](https://vercel.com/new/git/external?repository-u
 Vercel will help you make a new repo and deploy it..... and that should be it.
 
 After that you can also setup any custom domains in Settings > Domains
+::alert{type="info"}
+Note that some links may break in this documentation if you are not hosting on a custom domain (the links to the status page and main website on the homepage), as this guide expects you to. However, as is the nature with any open source project, you can simply edit it.
+::


### PR DESCRIPTION
Warn users that links may possibly break when self hosting, due to links expecting a custom domain, and some may not wish to host on a custom domain w/ Github Education